### PR TITLE
Removes default background color

### DIFF
--- a/frontend/src/styles/global/global.scss
+++ b/frontend/src/styles/global/global.scss
@@ -14,7 +14,6 @@ body {
     font-family: variables.$default-font, sans-serif;
     margin: 0;
     padding: 0;
-    background-color: hsl(0, 0%, 95%);
 }
 
 input,


### PR DESCRIPTION
Removes the default background color from the body to allow for more flexible theme customization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed the light gray background color from the app, allowing the background to inherit the default or parent color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->