### PR TITLE
Ensures dropdown appears above other elements

### DIFF
--- a/frontend/src/styles/navigation-dropdown.scss
+++ b/frontend/src/styles/navigation-dropdown.scss
@@ -8,6 +8,7 @@
 	box-shadow: 5px 5px 15px hsl(0, 0%, 60%);
 
 	border-radius: 6px;
+	z-index: 500;
 }
 
 .navigation-dropdown-link {


### PR DESCRIPTION
Adds a z-index to the navigation dropdown to ensure it is rendered above other page elements, resolving potential display issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the layering of the navigation dropdown to ensure it displays above other page elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->