### PR TITLE
Fix pass and play page not displaying  due to wrong type of gameOverM…

### DIFF
--- a/frontend/src/pages/protected/PassAndPlay.tsx
+++ b/frontend/src/pages/protected/PassAndPlay.tsx
@@ -11,18 +11,18 @@ import "../../styles/components/chessboard/board-actions.scss";
 import "../../styles/pages/pass-and-play.scss";
 
 import Chessboard from "../../globalComponents/chessboards/Chessboard.tsx";
-import GameOverModal from "../../globalComponents/modals/MultiplayerGameOverModal.tsx";
 import GameplaySettings from "../../globalComponents/modals/GameplaySettings.tsx";
 import ModalWrapper from "../../globalComponents/wrappers/ModalWrapper.tsx";
 import useGameplaySettings from "../../hooks/useGameplaySettings.ts";
 import { ParsedFENString } from "../../types/gameLogic.ts";
+import LocalGameOverModal from "../../globalComponents/modals/LocalGameOverModal.tsx";
 
 function PassAndPlay() {
 	const [parsedFEN, setParsedFEN] = useState<ParsedFENString | null>(null);
 
 	const [gameEnded, setGameEnded] = useState<boolean>(false);
 	const [gameEndedCause, setGameEndedCause] = useState<string>("");
-	const [gameWinner, setGameWinner] = useState<string | null>(null);
+	const [gameWinner, setGameWinner] = useState<string>("");
 
 	const initialGameplaySettings = useGameplaySettings();
 	const [gameplaySettings, setGameplaySettings] = useState(
@@ -99,7 +99,7 @@ function PassAndPlay() {
 								/>
 							</ModalWrapper>
 
-							<GameOverModal
+							<LocalGameOverModal
 								visible={gameEnded}
 								gameEndCause={gameEndedCause}
 								gameWinner={gameWinner}


### PR DESCRIPTION
Fix pass and play page not displaying due to MultiplayerGameOverModal being used instead of LocalGameOverModal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of the game over modal in Pass and Play mode by displaying the correct local version.
  - Enhanced reliability of winner display by standardizing the game winner state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->