### PR TITLE
Add GitHub action to regularly ping Render server

### DIFF
--- a/.github/workflows/render-server-pinger.yaml
+++ b/.github/workflows/render-server-pinger.yaml
@@ -1,0 +1,13 @@
+name: Keep Render Alive
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'  # every 5 minutes
+  workflow_dispatch:       # allows manual run from GitHub UI
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Render app healthcheck
+        run: curl -L --fail https://freechessweb.onrender.com/core/health-check/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced an automated workflow that regularly pings the application's health check endpoint to help keep the service active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->